### PR TITLE
Add cubemap channel support for ShaderToy packs

### DIFF
--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -25,8 +25,8 @@ mod wallpaper;
 mod window;
 
 pub use types::{
-    Antialiasing, ChannelBindings, ChannelSource, ColorSpaceMode, RenderMode, RendererConfig,
-    ShaderCompiler, SurfaceAlpha,
+    Antialiasing, ChannelBindings, ChannelSource, ChannelTextureKind, ColorSpaceMode, RenderMode,
+    RendererConfig, ShaderCompiler, SurfaceAlpha, CUBEMAP_FACE_STEMS,
 };
 pub use wallpaper::{
     OutputId, SurfaceId, SurfaceInfo, SurfaceSelector, SwapRequest, WallpaperRuntime,

--- a/crates/shadertoy/Cargo.toml
+++ b/crates/shadertoy/Cargo.toml
@@ -17,6 +17,7 @@ tracing.workspace = true
 toml = "0.8"
 reqwest.workspace = true
 directories-next = "2"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- collect unsupported or missing entry-pass channel details when building bindings
- surface aggregated warnings when running single shaders or playlists so issues are obvious in logs
- add full cubemap channel support across the loader, bindings, and renderer, including extracting zipped Shadertoy cubemap assets so affected shaders can render

## Testing
- cargo test -p hyshadew *(fails: unable to reach crates.io in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dd11c391f08327a9cc4998f6c8aa25